### PR TITLE
Fix configuration button

### DIFF
--- a/lib/ConfigButton.py
+++ b/lib/ConfigButton.py
@@ -3,23 +3,22 @@ from new_config import new_config_thread
 import _thread
 
 
-class ButtonPress:
+class ConfigButton:
     def __init__(self, logger):
 
         self.logger = logger
-        self.Press = True
         self.debounce_timer = Timer.Chrono()
         self.debounce_timer.start()
-        self.button_held = None
+        self.button_held = Timer.Alarm(None, s=2.5)
 
-    def press_handler(self, arg):
+    def button_handler(self, pin):
         if self.debounce_timer.read_ms() >= 10:  # 10 ms software switch debounce
             self.debounce_timer.reset()
-            if self.Press:
-                self.button_held = Timer.Alarm(self.start_config, 2.5, periodic=False)
-            else:
+            value = pin.value()
+            if value == 0:  # Button pressed
+                self.button_held = Timer.Alarm(self.start_config, s=2.5, periodic=False)
+            elif value == 1:  # Button released
                 self.button_held.cancel()
-            self.Press = not self.Press
 
     def start_config(self, arg):  # this handler is called when button was held for 2.5 sec
         _thread.start_new_thread(new_config_thread, ('New_Config', self.logger, 300))

--- a/main.py
+++ b/main.py
@@ -33,7 +33,7 @@ pycom.rgbled(0x552000)  # flash orange until its loaded
 # Initialize the rest
 try:
     from machine import Pin, unique_id, Timer
-    from ButtonPress import ButtonPress
+    from ConfigButton import ConfigButton
     from SensorLogger import SensorLogger
     from Configuration import config
     from EventScheduler import EventScheduler
@@ -57,9 +57,10 @@ try:
     # Read configuration file to get preferences
     config.read_configuration(status_logger)
 
-    user_button = ButtonPress(logger=status_logger)
+    # Initialize button interrupt on pin 14 for entering configurations page
+    config_button = ConfigButton(logger=status_logger)
     pin_14 = Pin("P14", mode=Pin.IN, pull=None)
-    pin_14.callback(Pin.IRQ_FALLING | Pin.IRQ_RISING, user_button.press_handler)
+    pin_14.callback(Pin.IRQ_RISING | Pin.IRQ_FALLING, config_button.button_handler)
 
     # Check if device is configured, or SD card has been moved to another device
     device_id = hexlify(unique_id()).upper().decode("utf-8")


### PR DESCRIPTION
Previously if the user pressed the button during initialization, the button got reversed, and configuration would start after the user released the button for 2.5 seconds instead of pressing it.
Now the state of the button is known, and user cannot switch polarities, configurations is only entered upon pressing the button for 2.5 seconds.